### PR TITLE
Implement workspace invite activation and refine user journey filtering

### DIFF
--- a/src/components/Dashboard/WorkspaceDataFetcher.tsx
+++ b/src/components/Dashboard/WorkspaceDataFetcher.tsx
@@ -18,6 +18,7 @@ import {
   updateUserRole,
   removeUser,
   createWorkspace,
+  activatePendingWorkspaceInvites,
   getUserRoles,
   createUserRole,
   updateCustomUserRole,
@@ -189,6 +190,8 @@ export function WorkspaceDataFetcher({
     try {
       setLoading(true)
 
+      await activatePendingWorkspaceInvites()
+
       const [workspacesData, workspaceUsersData] = await Promise.all([
         getWorkspaces(),
         getWorkspaceUsers(),
@@ -322,11 +325,11 @@ export function WorkspaceDataFetcher({
   const accessibleWorkspaces = useMemo(() => {
     const memberWorkspaceIds = new Set(
       workspaceUsers
-        .filter(wu => wu.status === 'active')
+        .filter(wu => wu.status === 'active' && wu.user_id === user?.id)
         .map(wu => wu.workspace_id)
     )
     return workspaces.filter(w => memberWorkspaceIds.has(w.id))
-  }, [workspaces, workspaceUsers])
+  }, [workspaces, workspaceUsers, user?.id])
 
   const filteredWorkspaceUsers = useMemo(
     () => workspaceUsers.filter(wu => wu.workspace_id === activeWorkspaceId),

--- a/src/lib/activeWorkspace.ts
+++ b/src/lib/activeWorkspace.ts
@@ -23,7 +23,24 @@ export function resolveActiveWorkspaceId(
   )
 
   if (stored && accessibleIds.has(stored)) {
+    const storedWorkspace = workspaces.find(w => w.id === stored)
+    const sharedWorkspace = workspaces.find(
+      w => accessibleIds.has(w.id) && w.created_by !== userId
+    )
+    const storedIsPersonal = storedWorkspace?.created_by === userId
+
+    // Prefer shared workspace over auto-created personal workspace
+    if (sharedWorkspace && storedIsPersonal && sharedWorkspace.id !== stored) {
+      setActiveWorkspaceId(sharedWorkspace.id)
+      return sharedWorkspace.id
+    }
+
     return stored
+  }
+
+  // Drop stale workspace selection (e.g. from another account on the same browser)
+  if (stored && !accessibleIds.has(stored)) {
+    localStorage.removeItem(ACTIVE_WORKSPACE_KEY)
   }
 
   // Prefer shared workspaces over personal ones (personal = created_by matches user)

--- a/src/lib/database/services/userJourneyFolderService.ts
+++ b/src/lib/database/services/userJourneyFolderService.ts
@@ -118,7 +118,7 @@ export async function createUserJourneyFolder(
       workspace_id: workspaceId,
       name,
       color,
-      status: 'personal', // Default to personal
+      status: 'shared',
       parent_folder_id: parentFolderId,
       created_by: user.id
     })

--- a/src/lib/database/services/userJourneyService.ts
+++ b/src/lib/database/services/userJourneyService.ts
@@ -46,88 +46,55 @@ export const getUserJourneys = async (
   }
 
   try {
-    // Get current user to filter journeys
-    const { data: { user } } = await supabase.auth.getUser()
-    const currentUserId = user?.id
-    
-    // Check if user is workspace owner or admin (they can see all journeys)
-    let isOwnerOrAdmin = false
-    if (currentUserId) {
-      try {
-        const { data: workspaceUser, error: roleError } = await supabase
-          .from('workspace_users')
-          .select('role')
-          .eq('user_id', currentUserId)
-          .single()
-        
-        // If query succeeds and user is owner/admin, grant access to all journeys
-        if (!roleError && workspaceUser && (workspaceUser.role === 'owner' || workspaceUser.role === 'admin')) {
-          isOwnerOrAdmin = true
-        }
-      } catch (error) {
-        // If there's an error checking role, fall back to regular filtering
-        console.warn('Could not check user role, using default filtering:', error)
-      }
-    }
-    
-    // Fetch journeys and folders in parallel
     let query = supabase
       .from('user_journeys')
       .select('*')
       .order('created_at', { ascending: false })
 
-    // Filter by project if provided
     if (projectId) {
       query = query.eq('project_id', projectId)
     }
 
-    const [journeysResult, foldersResult] = await Promise.all([
+    const foldersPromise = workspaceIdForFolders
+      ? getUserJourneyFolders(workspaceIdForFolders)
+      : Promise.resolve([])
+
+    const projectsPromise =
+      workspaceIdForFolders && supabase
+        ? supabase.from('projects').select('id').eq('workspace_id', workspaceIdForFolders)
+        : Promise.resolve({ data: null, error: null })
+
+    const [journeysResult, foldersResult, projectsResult] = await Promise.all([
       query,
-      getUserJourneyFolders(workspaceIdForFolders).catch(() => [])
+      foldersPromise.catch(() => []),
+      projectsPromise,
     ])
 
     const { data, error } = journeysResult
     const folders = foldersResult || []
 
     if (error) throw error
-    
-    // Create a map of folder IDs to folder status
-    const folderStatusMap = new Map<string, 'personal' | 'shared'>()
-    folders.forEach(folder => {
-      folderStatusMap.set(folder.id, folder.status)
-    })
-    
-    // Helper function to get journey status from folder
-    const getJourneyStatus = (journey: any): 'personal' | 'shared' => {
-      if (!journey.folder_id) return 'personal'
-      return folderStatusMap.get(journey.folder_id) || 'personal'
+
+    let journeys = data || []
+
+    // Scope to the active workspace — RLS may return journeys from multiple workspaces
+    if (workspaceIdForFolders) {
+      const folderIdsInWorkspace = new Set(folders.map(f => f.id))
+      const projectIdsInWorkspace = new Set(
+        (projectsResult.data || []).map((p: { id: string }) => p.id)
+      )
+
+      journeys = journeys.filter(journey =>
+        (journey.folder_id && folderIdsInWorkspace.has(journey.folder_id)) ||
+        (journey.project_id && projectIdsInWorkspace.has(journey.project_id))
+      )
     }
-    
-    // If user is owner/admin, show all journeys
-    if (isOwnerOrAdmin) {
-      return (data || []).map((journey: any) => {
-        // Remove status if it exists (legacy data)
-        const { status, ...journeyWithoutStatus } = journey
-        return journeyWithoutStatus
-      })
-    }
-    
-    // Filter results: show shared journeys (in shared folders) to all, but personal journeys only to creator
-    const filteredData = (data || []).filter((journey: any) => {
-      // Determine journey status from folder
-      const isShared = getJourneyStatus(journey) === 'shared'
-      
-      // If shared, show to everyone
-      if (isShared) return true
-      // If personal, only show to creator
-      return journey.created_by === currentUserId
-    }).map((journey: any) => {
-      // Remove status if it exists (legacy data)
-      const { status, ...journeyWithoutStatus } = journey
+
+    // Workspace members see all journeys RLS allows — no personal/shared filtering
+    return journeys.map((journey: UserJourney & { status?: string }) => {
+      const { status: _status, ...journeyWithoutStatus } = journey
       return journeyWithoutStatus
     })
-    
-    return filteredData
   } catch (error) {
     console.error('Error fetching user journeys:', error)
     

--- a/src/lib/database/services/workspaceService.ts
+++ b/src/lib/database/services/workspaceService.ts
@@ -1,6 +1,19 @@
 import { supabase, isSupabaseConfigured } from '../../supabase'
 import type { Workspace, WorkspaceUser } from '../../supabase'
 
+export const activatePendingWorkspaceInvites = async (): Promise<void> => {
+  if (!isSupabaseConfigured || !supabase) return
+
+  try {
+    const { error } = await supabase.rpc('activate_my_pending_invites')
+    if (error) {
+      console.error('Error activating pending workspace invites:', error)
+    }
+  } catch (error) {
+    console.error('Error activating pending workspace invites:', error)
+  }
+}
+
 export const createWorkspace = async (
   name: string
 ): Promise<{ workspace: Workspace | null; error: string | null }> => {
@@ -32,7 +45,6 @@ export const createWorkspace = async (
   }
 }
 
-// Workspace functions
 export const getWorkspaces = async (): Promise<Workspace[]> => {
   if (!isSupabaseConfigured || !supabase) {
     // Local storage fallback

--- a/supabase/functions/invite-team-member/index.ts
+++ b/supabase/functions/invite-team-member/index.ts
@@ -177,35 +177,55 @@ serve(async (req) => {
       )
     }
 
-    const { error: inviteError } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
-      redirectTo: `${req.headers.get('origin') || 'http://localhost:5173'}/`,
-      data: {
-        workspace_id: workspaceId,
-        role: role
-      }
-    })
+    const normalizedEmail = email.toLowerCase().trim()
 
-    if (inviteError) {
-      console.error('Error inviting user:', inviteError)
-      return new Response(
-        JSON.stringify({ error: `Failed to send invitation: ${inviteError.message}` }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    const { data: existingAuthUserRow, error: authLookupError } = await supabaseAdmin
+      .schema('auth')
+      .from('users')
+      .select('id, email')
+      .ilike('email', normalizedEmail)
+      .maybeSingle()
+
+    if (authLookupError) {
+      console.error('Error looking up auth user:', authLookupError)
+    }
+
+    const existingAuthUser = existingAuthUserRow
+      ? { id: existingAuthUserRow.id, email: existingAuthUserRow.email }
+      : null
+
+    if (!existingAuthUser) {
+      const { error: inviteError } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
+        redirectTo: `${req.headers.get('origin') || 'http://localhost:5173'}/`,
+        data: {
+          workspace_id: workspaceId,
+          role: role
         }
-      )
+      })
+
+      if (inviteError) {
+        console.error('Error inviting user:', inviteError)
+        return new Response(
+          JSON.stringify({ error: `Failed to send invitation: ${inviteError.message}` }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          }
+        )
+      }
     }
 
     const { data: workspaceUser, error: workspaceUserError } = await supabaseAdmin
       .from('workspace_users')
       .insert([{
         workspace_id: workspaceId,
+        user_id: existingAuthUser?.id ?? null,
         user_email: email,
         full_name: fullName || null,
         team: team || null,
         role: role,
         invited_by: user.id,
-        status: 'pending'
+        status: existingAuthUser ? 'active' : 'pending'
       }])
       .select()
       .single()
@@ -225,7 +245,9 @@ serve(async (req) => {
       JSON.stringify({
         success: true,
         user: workspaceUser,
-        message: `Invitation sent to ${email}`
+        message: existingAuthUser
+          ? `${email} added to workspace`
+          : `Invitation sent to ${email}`
       }),
       {
         status: 200,

--- a/supabase/migrations/20260528120000_activate_invites_on_signin.sql
+++ b/supabase/migrations/20260528120000_activate_invites_on_signin.sql
@@ -1,0 +1,94 @@
+/*
+  Activate pending workspace invites for existing users.
+
+  New signups were already handled by activate_pending_workspace_invites on INSERT.
+  Existing auth users who are invited remain pending until they sign in again.
+*/
+
+CREATE OR REPLACE FUNCTION public.activate_pending_workspace_invites_for_user(p_user_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text;
+  v_updated integer;
+BEGIN
+  SELECT email INTO v_email
+  FROM auth.users
+  WHERE id = p_user_id;
+
+  IF v_email IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  UPDATE public.workspace_users
+  SET user_id = p_user_id,
+      status = 'active',
+      updated_at = now()
+  WHERE user_email = v_email
+    AND user_id IS NULL
+    AND status = 'pending';
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.activate_my_pending_invites()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  RETURN public.activate_pending_workspace_invites_for_user(auth.uid());
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.activate_pending_workspace_invites_for_user(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.activate_my_pending_invites() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.activate_my_pending_invites() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.activate_pending_workspace_invites_on_signin()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.email IS NOT NULL
+     AND (TG_OP = 'INSERT' OR OLD.last_sign_in_at IS DISTINCT FROM NEW.last_sign_in_at) THEN
+    PERFORM public.activate_pending_workspace_invites_for_user(NEW.id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_activate_invites ON auth.users;
+CREATE TRIGGER on_auth_user_activate_invites
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.activate_pending_workspace_invites_on_signin();
+
+DROP TRIGGER IF EXISTS on_auth_user_signin_activate_invites ON auth.users;
+CREATE TRIGGER on_auth_user_signin_activate_invites
+  AFTER UPDATE OF last_sign_in_at ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.activate_pending_workspace_invites_on_signin();
+
+-- Backfill: link any pending invites to existing auth accounts
+UPDATE public.workspace_users wu
+SET user_id = au.id,
+    status = 'active',
+    updated_at = now()
+FROM auth.users au
+WHERE wu.user_email = au.email
+  AND wu.user_id IS NULL
+  AND wu.status = 'pending';


### PR DESCRIPTION
- Added functionality to activate pending workspace invites for existing users upon sign-in.
- Updated the WorkspaceDataFetcher to call the new invite activation function.
- Enhanced user journey filtering to ensure only relevant journeys are displayed based on active workspace context.
- Changed default status for newly created user journey folders from 'personal' to 'shared' to align with workspace sharing practices.
- Introduced SQL migrations to support the new invite activation logic and ensure data integrity.